### PR TITLE
Refactor: Move 'Nos Offres' items to header dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,9 @@
                 <div class="dropdown-menu">
                     <a href="features/user/index.html">Se connecter</a>
                     <a href="#contact-group">Contact</a>
+                    <a href="features/services/index.html">Développement Logiciel Data & IA</a>
+                    <a href="features/products/index.html">Impression 3D</a>
+                    <a href="features/datagenerator/index.html">Données Synthétiques</a>
                 </div>
             </div>
         </header>
@@ -72,24 +75,7 @@
                             ></div>
                         </div>
                         <a href="#contact-group" class="cta-button">Contact</a>
-                        <div class="dropdown-container">
-                            <button
-                                class="cta-button cta-button-secondary dropdown-toggle"
-                            >
-                                Nos Offres
-                            </button>
-                            <div class="dropdown-content">
-                                <a href="features/services/index.html"
-                                    >Développement Logiciel Data & IA</a
-                                >
-                                <a href="features/products/index.html"
-                                    >Impression 3D</a
-                                >
-                                <a href="features/datagenerator/index.html"
-                                    >Données Synthétiques</a
-                                >
-                            </div>
-                        </div>
+                        <a href="#nos-entites" class="cta-button cta-button-secondary">Nos Offres</a>
                     </div>
                 </div>
                 <div class="scroll-indicator">


### PR DESCRIPTION
I have moved the items from the 'Nos Offres' dropdown ('Développement Logiciel Data & IA', 'Impression 3D', 'Données Synthétiques') to the main dropdown menu in the header.

I also removed the original 'Nos Offres' dropdown container, replacing it with a new 'Nos Offres' link that now scrolls to the 'Notre écosystème' section of the page.